### PR TITLE
Refactor a private utility function for frequency grid construction

### DIFF
--- a/dask_ndfourier/_compat.py
+++ b/dask_ndfourier/_compat.py
@@ -113,8 +113,14 @@ def _fftfreq(n, d=1.0, chunks=None):
     n_1 = n + 1
     n_2 = n_1 // 2
 
-    l = dask.array.linspace(0, 1, n_1, chunks=chunks)
-    r = dask.array.concatenate([l[:n_2], l[n_2:-1] - 1])
-    r /= d
+    s = dask.array.linspace(0, 1, n_1, chunks=chunks)
 
-    return r
+    l, r = s[:n_2], s[n_2:-1]
+
+    a = l
+    if len(r):
+        a = dask.array.concatenate([l, r - 1])
+
+    a /= d
+
+    return a

--- a/dask_ndfourier/_compat.py
+++ b/dask_ndfourier/_compat.py
@@ -67,3 +67,54 @@ def _indices(dimensions, dtype=int, chunks=None):
         )
 
     return grid
+
+
+def _fftfreq(n, d=1.0, chunks=None):
+    """
+    Return the Discrete Fourier Transform sample frequencies.
+
+    The returned float array `f` contains the frequency bin centers in cycles
+    per unit of the sample spacing (with zero at the start).  For instance, if
+    the sample spacing is in seconds, then the frequency unit is cycles/second.
+
+    Given a window length `n` and a sample spacing `d`::
+
+      f = [0, 1, ...,   n/2-1,     -n/2, ..., -1] / (d*n)   if n is even
+      f = [0, 1, ..., (n-1)/2, -(n-1)/2, ..., -1] / (d*n)   if n is odd
+
+    Parameters
+    ----------
+    n : int
+        Window length.
+    d : scalar, optional
+        Sample spacing (inverse of the sampling rate). Defaults to 1.
+
+    Returns
+    -------
+    grid : dask array
+
+    Examples
+    --------
+    >>> signal = np.array([-2, 8, 6, 4, 1, 0, 3, 5], dtype=float)
+    >>> fourier = np.fft.fft(signal)
+    >>> n = signal.size
+    >>> timestep = 0.1
+    >>> freq = np.fft.fftfreq(n, d=timestep)
+    >>> freq
+    array([ 0.  ,  1.25,  2.5 ,  3.75, -5.  , -3.75, -2.5 , -1.25])
+
+    Notes
+    -----
+    Borrowed from my Dask Array contribution.
+    """
+    n = int(n)
+    chunks = dask.array.core.normalize_chunks(chunks, (n,))[0] + (1,)
+
+    n_1 = n + 1
+    n_2 = n_1 // 2
+
+    l = dask.array.linspace(0, 1, n_1, chunks=chunks)
+    r = dask.array.concatenate([l[:n_2], l[n_2:-1] - 1])
+    r /= d
+
+    return r

--- a/dask_ndfourier/_compat.py
+++ b/dask_ndfourier/_compat.py
@@ -8,67 +8,6 @@ import numpy
 import dask.array
 
 
-def _indices(dimensions, dtype=int, chunks=None):
-    """
-    Implements NumPy's ``indices`` for Dask Arrays.
-    Generates a grid of indices covering the dimensions provided.
-    The final array has the shape ``(len(dimensions), *dimensions)``. The
-    chunks are used to specify the chunking for axis 1 up to
-    ``len(dimensions)``. The 0th axis always has chunks of length 1.
-
-    Parameters
-    ----------
-    dimensions : sequence of ints
-        The shape of the index grid.
-    dtype : dtype, optional
-        Type to use for the array. Default is ``int``.
-    chunks : sequence of ints
-        The number of samples on each block. Note that the last block will
-        have fewer samples if ``len(array) % chunks != 0``.
-
-    Returns
-    -------
-    grid : dask array
-
-    Notes
-    -----
-    Borrowed from my Dask Array contribution.
-    """
-    if chunks is None:
-        raise ValueError("Must supply a chunks= keyword argument")
-
-    dimensions = tuple(dimensions)
-    dtype = numpy.dtype(dtype)
-    chunks = tuple(chunks)
-
-    if len(dimensions) != len(chunks):
-        raise ValueError("Need one more chunk than dimensions.")
-
-    grid = []
-    if numpy.prod(dimensions):
-        for i in range(len(dimensions)):
-            s = len(dimensions) * [None]
-            s[i] = slice(None)
-            s = tuple(s)
-
-            r = dask.array.arange(dimensions[i], dtype=dtype, chunks=chunks[i])
-            r = r[s]
-
-            for j in itertools.chain(range(i), range(i + 1, len(dimensions))):
-                r = r.repeat(dimensions[j], axis=j)
-
-            grid.append(r)
-
-    if grid:
-        grid = dask.array.stack(grid)
-    else:
-        grid = dask.array.empty(
-            (len(dimensions),) + dimensions, dtype=dtype, chunks=(1,) + chunks
-        )
-
-    return grid
-
-
 def _fftfreq(n, d=1.0, chunks=None):
     """
     Return the Discrete Fourier Transform sample frequencies.

--- a/dask_ndfourier/core.py
+++ b/dask_ndfourier/core.py
@@ -118,24 +118,16 @@ def fourier_shift(input, shift, n=-1, axis=-1):
         )
 
     # Constants with type converted
-    pi = input.dtype.type(numpy.pi)
     J = input.dtype.type(1j)
 
-    # Compute the wave vector for this data
-    wave_vector = numpy.array(input.shape, dtype=input.dtype)
-    wave_vector = numpy.reciprocal(wave_vector, out=wave_vector)
-    wave_vector *= 2 * pi
-    wave_vector = dask.array.from_array(wave_vector, chunks=wave_vector.shape)
-
-    # Determine the unit shift in Fourier space for each dimension
-    fourier_unit_shift = _compat._indices(
+    # Get the grid of frequencies
+    freq_grid = _get_freq_grid(
         input.shape, dtype=input.dtype, chunks=input.chunks
     )
-    fourier_unit_shift *= -wave_vector[(slice(None),) + input.ndim * (None,)]
 
     # Apply shift
     phase_shift = dask.array.exp(
-        J * dask.array.tensordot(shift, fourier_unit_shift, axes=1)
+        - J * dask.array.tensordot(shift, freq_grid, axes=1)
     )
     result = input * phase_shift
 

--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -8,6 +8,7 @@ import pytest
 import numpy as np
 
 import dask
+import dask.array as da
 import dask.array.utils as dau
 
 import dask_ndfourier._compat
@@ -69,3 +70,12 @@ def test_indicies():
     darr = dask_ndfourier._compat._indices((2, 3), chunks=(1, 2))
     nparr = np.indices((2, 3))
     dau.assert_eq(darr, nparr)
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 6, 7])
+@pytest.mark.parametrize("d", [1.0, 0.5, 2 * np.pi])
+def test_fftfreq(n, d):
+    dau.assert_eq(
+        dask_ndfourier._compat._fftfreq(n, d, chunks=((n,),)),
+        np.fft.fftfreq(n, d)
+    )

--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -1,75 +1,13 @@
 # -*- coding: utf-8 -*-
 
 
-import distutils.version as ver
-
 import pytest
 
 import numpy as np
 
-import dask
-import dask.array as da
 import dask.array.utils as dau
 
 import dask_ndfourier._compat
-
-
-old_dask = ver.LooseVersion(dask.__version__) <= ver.LooseVersion("0.13.0")
-
-
-def test_indices_no_chunks():
-    with pytest.raises(ValueError):
-        dask_ndfourier._compat._indices((1,))
-
-
-def test_indices_wrong_chunks():
-    with pytest.raises(ValueError):
-        dask_ndfourier._compat._indices((1,), chunks=tuple())
-
-
-@pytest.mark.parametrize(
-    "dimensions, dtype, chunks",
-    [
-        (tuple(), int, tuple()),
-        (tuple(), float, tuple()),
-        ((0,), float, (1,)),
-        ((0, 1, 2), float, (1, 1, 2)),
-    ]
-)
-def test_empty_indicies(dimensions, dtype, chunks):
-    darr = dask_ndfourier._compat._indices(dimensions, dtype, chunks=chunks)
-    nparr = np.indices(dimensions, dtype)
-
-    assert darr.shape == nparr.shape
-    assert darr.dtype == nparr.dtype
-
-    try:
-        dau.assert_eq(darr, nparr)
-    except IndexError:
-        if len(dimensions) and old_dask:
-            pytest.skip(
-                "Dask pre-0.14.0 is unable to compute this empty array."
-            )
-        else:
-            raise
-
-
-def test_indicies():
-    darr = dask_ndfourier._compat._indices((1,), chunks=(1,))
-    nparr = np.indices((1,))
-    dau.assert_eq(darr, nparr)
-
-    darr = dask_ndfourier._compat._indices((1,), float, chunks=(1,))
-    nparr = np.indices((1,), float)
-    dau.assert_eq(darr, nparr)
-
-    darr = dask_ndfourier._compat._indices((2, 1), chunks=(2, 1))
-    nparr = np.indices((2, 1))
-    dau.assert_eq(darr, nparr)
-
-    darr = dask_ndfourier._compat._indices((2, 3), chunks=(1, 2))
-    nparr = np.indices((2, 3))
-    dau.assert_eq(darr, nparr)
 
 
 @pytest.mark.parametrize("n", [1, 2, 3, 6, 7])


### PR DESCRIPTION
Instead of handling frequency grid construction inside `fourier_shift`, move it into a separate function. Also correct a sign issue in the phases in the process, which should allow for issue ( https://github.com/dask-image/dask-ndfourier/issues/4 ) to be addressed. Vendor `fftfreq` from our contributions to Dask Array to aid in this work. Also drop the vendored `indices` as it is no longer needed.