### PR TITLE
Tidy tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -46,24 +46,18 @@ def test_fourier_shift_err(err_type, shift, n):
         (0, 0),
     ]
 )
-def test_fourier_shift_identity(shift):
-    a = np.arange(140.0).reshape(10, 14).astype(complex)
+@pytest.mark.parametrize(
+    "in_dtype, out_dtype",
+    [
+        (complex, complex),
+        (float, complex),
+    ]
+)
+def test_fourier_shift_identity(shift, in_dtype, out_dtype):
+    a = np.arange(140.0).reshape(10, 14).astype(in_dtype)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(d, da_ndf.fourier_shift(d, shift))
-
-    dau.assert_eq(
-        sp_ndf.fourier_shift(a, shift), da_ndf.fourier_shift(d, shift)
-    )
-
-
-def test_fourier_shift_real():
-    shift = 0
-
-    a = np.arange(140.0).reshape(10, 14)
-    d = da.from_array(a, chunks=(5, 7))
-
-    dau.assert_eq(d.astype(complex), da_ndf.fourier_shift(d, shift))
+    dau.assert_eq(d.astype(out_dtype), da_ndf.fourier_shift(d, shift))
 
     dau.assert_eq(
         sp_ndf.fourier_shift(a, shift), da_ndf.fourier_shift(d, shift)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -84,16 +84,39 @@ def test_fourier_filter_identity(funcname, arg1_, in_dtype, out_dtype):
 @pytest.mark.parametrize(
     "arg1_",
     [
-        1,
-        0.5,
         -1,
-        (1, 1),
-        (0.8, 1.5),
         (-1, -1),
-        (1, 0),
-        (0, 2),
         (-1, 2),
         (10, -9),
+    ]
+)
+@pytest.mark.parametrize(
+    "funcname",
+    [
+        "fourier_shift",
+    ]
+)
+def test_fourier_filter_negative(funcname, arg1_):
+    da_func = getattr(da_ndf, funcname)
+    sp_func = getattr(sp_ndf, funcname)
+
+    a = np.arange(140.0).reshape(10, 14).astype(complex)
+    d = da.from_array(a, chunks=(5, 7))
+
+    dau.assert_eq(
+        sp_func(a, arg1_), da_func(d, arg1_)
+    )
+
+
+@pytest.mark.parametrize(
+    "arg1_",
+    [
+        1,
+        0.5,
+        (1, 1),
+        (0.8, 1.5),
+        (1, 0),
+        (0, 2),
     ]
 )
 @pytest.mark.parametrize(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -85,7 +85,7 @@ def test_fourier_shift_real():
         (10, -9),
     ]
 )
-def test_fourier_shift_identity(shift):
+def test_fourier_shift(shift):
     a = np.arange(140.0).reshape(10, 14).astype(complex)
     d = da.from_array(a, chunks=(5, 7))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -21,7 +21,7 @@ def test_import_core():
 
 
 @pytest.mark.parametrize(
-    "err_type, shift, n",
+    "err_type, arg1_, n",
     [
         (NotImplementedError, 0.0, 0),
         (TypeError, 0.0 + 0.0j, 0),
@@ -31,16 +31,16 @@ def test_import_core():
         (NotImplementedError, 0, 0),
     ]
 )
-def test_fourier_shift_err(err_type, shift, n):
+def test_fourier_shift_err(err_type, arg1_, n):
     a = np.arange(140.0).reshape(10, 14).astype(complex)
     d = da.from_array(a, chunks=(5, 7))
 
     with pytest.raises(err_type):
-        da_ndf.fourier_shift(d, shift, n)
+        da_ndf.fourier_shift(d, arg1_, n)
 
 
 @pytest.mark.parametrize(
-    "shift",
+    "arg1_",
     [
         0,
         (0, 0),
@@ -53,19 +53,19 @@ def test_fourier_shift_err(err_type, shift, n):
         (float, complex),
     ]
 )
-def test_fourier_shift_identity(shift, in_dtype, out_dtype):
+def test_fourier_shift_identity(arg1_, in_dtype, out_dtype):
     a = np.arange(140.0).reshape(10, 14).astype(in_dtype)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(d.astype(out_dtype), da_ndf.fourier_shift(d, shift))
+    dau.assert_eq(d.astype(out_dtype), da_ndf.fourier_shift(d, arg1_))
 
     dau.assert_eq(
-        sp_ndf.fourier_shift(a, shift), da_ndf.fourier_shift(d, shift)
+        sp_ndf.fourier_shift(a, arg1_), da_ndf.fourier_shift(d, arg1_)
     )
 
 
 @pytest.mark.parametrize(
-    "shift",
+    "arg1_",
     [
         1,
         0.5,
@@ -79,10 +79,10 @@ def test_fourier_shift_identity(shift, in_dtype, out_dtype):
         (10, -9),
     ]
 )
-def test_fourier_shift(shift):
+def test_fourier_shift(arg1_):
     a = np.arange(140.0).reshape(10, 14).astype(complex)
     d = da.from_array(a, chunks=(5, 7))
 
     dau.assert_eq(
-        sp_ndf.fourier_shift(a, shift), da_ndf.fourier_shift(d, shift)
+        sp_ndf.fourier_shift(a, arg1_), da_ndf.fourier_shift(d, arg1_)
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -31,12 +31,20 @@ def test_import_core():
         (NotImplementedError, 0, 0),
     ]
 )
-def test_fourier_shift_err(err_type, arg1_, n):
+@pytest.mark.parametrize(
+    "funcname",
+    [
+        "fourier_shift",
+    ]
+)
+def test_fourier_filter_err(funcname, err_type, arg1_, n):
+    da_func = getattr(da_ndf, funcname)
+
     a = np.arange(140.0).reshape(10, 14).astype(complex)
     d = da.from_array(a, chunks=(5, 7))
 
     with pytest.raises(err_type):
-        da_ndf.fourier_shift(d, arg1_, n)
+        da_func(d, arg1_, n)
 
 
 @pytest.mark.parametrize(
@@ -53,14 +61,23 @@ def test_fourier_shift_err(err_type, arg1_, n):
         (float, complex),
     ]
 )
-def test_fourier_shift_identity(arg1_, in_dtype, out_dtype):
+@pytest.mark.parametrize(
+    "funcname",
+    [
+        "fourier_shift",
+    ]
+)
+def test_fourier_filter_identity(funcname, arg1_, in_dtype, out_dtype):
+    da_func = getattr(da_ndf, funcname)
+    sp_func = getattr(sp_ndf, funcname)
+
     a = np.arange(140.0).reshape(10, 14).astype(in_dtype)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(d.astype(out_dtype), da_ndf.fourier_shift(d, arg1_))
+    dau.assert_eq(d.astype(out_dtype), da_func(d, arg1_))
 
     dau.assert_eq(
-        sp_ndf.fourier_shift(a, arg1_), da_ndf.fourier_shift(d, arg1_)
+        sp_func(a, arg1_), da_func(d, arg1_)
     )
 
 
@@ -79,10 +96,19 @@ def test_fourier_shift_identity(arg1_, in_dtype, out_dtype):
         (10, -9),
     ]
 )
-def test_fourier_shift(arg1_):
+@pytest.mark.parametrize(
+    "funcname",
+    [
+        "fourier_shift",
+    ]
+)
+def test_fourier_filter(funcname, arg1_):
+    da_func = getattr(da_ndf, funcname)
+    sp_func = getattr(sp_ndf, funcname)
+
     a = np.arange(140.0).reshape(10, 14).astype(complex)
     d = da.from_array(a, chunks=(5, 7))
 
     dau.assert_eq(
-        sp_ndf.fourier_shift(a, arg1_), da_ndf.fourier_shift(d, arg1_)
+        sp_func(a, arg1_), da_func(d, arg1_)
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -55,10 +55,10 @@ def test_fourier_filter_err(funcname, err_type, arg1_, n):
     ]
 )
 @pytest.mark.parametrize(
-    "in_dtype, out_dtype",
+    "dtype",
     [
-        (complex, complex),
-        (float, complex),
+        float,
+        complex,
     ]
 )
 @pytest.mark.parametrize(
@@ -67,18 +67,17 @@ def test_fourier_filter_err(funcname, err_type, arg1_, n):
         "fourier_shift",
     ]
 )
-def test_fourier_filter_identity(funcname, arg1_, in_dtype, out_dtype):
+def test_fourier_filter_identity(funcname, arg1_, dtype):
     da_func = getattr(da_ndf, funcname)
     sp_func = getattr(sp_ndf, funcname)
 
-    a = np.arange(140.0).reshape(10, 14).astype(in_dtype)
+    a = np.arange(140.0).reshape(10, 14).astype(dtype)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(d.astype(out_dtype), da_func(d, arg1_))
+    x = sp_func(a, arg1_)
 
-    dau.assert_eq(
-        sp_func(a, arg1_), da_func(d, arg1_)
-    )
+    dau.assert_eq(d.astype(x.dtype), da_func(d, arg1_))
+    dau.assert_eq(x, da_func(d, arg1_))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
First fix a test function that had an overlapping name. Second consolidate two very similar identity tests into a single parameterized one. Third generalize tests to make it easier to parameterize them with different test functions later. Fourth split out negative argument comparisons from positive ones. Those usually only make sense for computing a shift not a filter.