### PR TITLE
Add an implementation of fourier_gaussian

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -35,6 +35,7 @@ def test_import_core():
     "funcname",
     [
         "fourier_shift",
+        "fourier_gaussian",
     ]
 )
 def test_fourier_filter_err(funcname, err_type, arg1_, n):
@@ -66,6 +67,7 @@ def test_fourier_filter_err(funcname, err_type, arg1_, n):
     "funcname",
     [
         "fourier_shift",
+        "fourier_gaussian",
     ]
 )
 def test_fourier_filter_identity(funcname, arg1_, dtype):
@@ -94,6 +96,7 @@ def test_fourier_filter_identity(funcname, arg1_, dtype):
     "funcname",
     [
         "fourier_shift",
+        "fourier_gaussian",
     ]
 )
 def test_fourier_filter_negative(funcname, arg1_):
@@ -123,6 +126,7 @@ def test_fourier_filter_negative(funcname, arg1_):
     "funcname",
     [
         "fourier_shift",
+        "fourier_gaussian",
     ]
 )
 def test_fourier_filter(funcname, arg1_):


### PR DESCRIPTION
Partially addresses ( https://github.com/dask-image/dask-ndfourier/issues/2 )

Provides a function equivalent to SciPy ndimage's [`fourier_gaussian`]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.fourier_gaussian.html ) using Dask Arrays. Simply computes the Fourier transform of the normal distribution on the frequency grid. Reuses some of the existing tests for `fourier_shift` with `fourier_gaussian` thanks to their parameterization.