### PR TITLE
Join negative and zero valued tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -90,6 +90,8 @@ def test_fourier_filter_identity(funcname, s, dtype):
         (-1, -1),
         (-1, 2),
         (10, -9),
+        (1, 0),
+        (0, 2),
     ]
 )
 @pytest.mark.parametrize(
@@ -99,7 +101,7 @@ def test_fourier_filter_identity(funcname, s, dtype):
         "fourier_gaussian",
     ]
 )
-def test_fourier_filter_negative(funcname, s):
+def test_fourier_filter_non_positive(funcname, s):
     da_func = getattr(da_ndf, funcname)
     sp_func = getattr(sp_ndf, funcname)
 
@@ -118,8 +120,6 @@ def test_fourier_filter_negative(funcname, s):
         0.5,
         (1, 1),
         (0.8, 1.5),
-        (1, 0),
-        (0, 2),
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Zero values for filter sizes and shifts are a bit of a strange thing. Stranger still are negative values, which breakdown on many filters. Surprisingly they work well for the Gaussian filter in SciPy (less surprisingly for our implementation). However these are really odd to consider for the uniform filter. So go ahead and move these out of the standard filter tests and join them with the negative size and shift tests. That way these can be opted into if they make sense.