### PR TITLE
Add fourier uniform

### DIFF
--- a/dask_ndfourier/_compat.py
+++ b/dask_ndfourier/_compat.py
@@ -63,3 +63,6 @@ def _fftfreq(n, d=1.0, chunks=None):
     a /= d
 
     return a
+
+
+_sinc = dask.array.ufunc.wrap_elemwise(numpy.sinc)

--- a/dask_ndfourier/core.py
+++ b/dask_ndfourier/core.py
@@ -198,3 +198,74 @@ def fourier_shift(input, shift, n=-1, axis=-1):
     result = input * phase_shift
 
     return result
+
+
+def fourier_uniform(input, size, n=-1, axis=-1):
+    """
+    Multi-dimensional uniform fourier filter.
+
+    The array is multiplied with the fourier transform of a box of given
+    size.
+
+    Parameters
+    ----------
+    input : array_like
+        The input array.
+    size : float or sequence
+        The size of the box used for filtering.
+        If a float, `size` is the same for all axes. If a sequence, `size` has
+        to contain one value for each axis.
+    n : int, optional
+        If `n` is negative (default), then the input is assumed to be the
+        result of a complex fft.
+        If `n` is larger than or equal to zero, the input is assumed to be the
+        result of a real fft, and `n` gives the length of the array before
+        transformation along the real transform direction.
+    axis : int, optional
+        The axis of the real transform.
+
+    Returns
+    -------
+    fourier_uniform : Dask Array
+        The filtered input. If `output` is given as a parameter, None is
+        returned.
+
+    Examples
+    --------
+    >>> from scipy import ndimage, misc
+    >>> import numpy.fft
+    >>> import matplotlib.pyplot as plt
+    >>> fig, (ax1, ax2) = plt.subplots(1, 2)
+    >>> plt.gray()  # show the filtered result in grayscale
+    >>> ascent = misc.ascent()
+    >>> input_ = numpy.fft.fft2(ascent)
+    >>> result = ndimage.fourier_uniform(input_, size=20)
+    >>> result = numpy.fft.ifft2(result)
+    >>> ax1.imshow(ascent)
+    >>> ax2.imshow(result.real)  # the imaginary part is an artifact
+    >>> plt.show()
+    """
+
+    if issubclass(input.dtype.type, numbers.Integral):
+        input = input.astype(float)
+
+    # Validate and normalize arguments
+    size, n, axis = _norm_args(input, size, n=n, axis=axis)
+
+    # Get the grid of frequencies
+    freq_grid = _get_freq_grid(
+        input.shape, dtype=input.dtype, chunks=input.chunks
+    )
+
+    # Constants with type converted
+    pi = input.dtype.type(numpy.pi).real
+
+    # Compute uniform filter
+    uniform = _compat._sinc(
+        size[(slice(None),) + input.ndim * (None,)] * freq_grid / (2 * pi)
+    )
+    uniform = dask.array.prod(uniform, axis=0)
+
+    result = input * uniform
+
+    return result

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -36,6 +36,7 @@ def test_import_core():
     [
         "fourier_shift",
         "fourier_gaussian",
+        "fourier_uniform",
     ]
 )
 def test_fourier_filter_err(funcname, err_type, s, n):
@@ -86,6 +87,7 @@ def test_fourier_filter_identity(funcname, s):
     [
         "fourier_shift",
         "fourier_gaussian",
+        "fourier_uniform",
     ]
 )
 def test_fourier_filter_type(funcname, dtype):
@@ -144,6 +146,7 @@ def test_fourier_filter_non_positive(funcname, s):
     [
         "fourier_shift",
         "fourier_gaussian",
+        "fourier_uniform",
     ]
 )
 def test_fourier_filter(funcname, s):


### PR DESCRIPTION
Partially addresses ( https://github.com/dask-image/dask-ndfourier/issues/2 )

Provides a function equivalent to SciPy ndimage's [`fourier_uniform`]( https://docs.scipy.org/doc/scipy-0.19.0/reference/generated/scipy.ndimage.fourier_uniform.html ) using Dask Arrays. Simply computes the Fourier transform of the `rect` function rescaled on the frequency grid. Reuses some of the existing parameterized tests to also test `fourier_uniform` and compare its results to SciPy ndimage's equivalent.