### PR TITLE
Break up the identity and type tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -56,6 +56,24 @@ def test_fourier_filter_err(funcname, err_type, s, n):
     ]
 )
 @pytest.mark.parametrize(
+    "funcname",
+    [
+        "fourier_shift",
+        "fourier_gaussian",
+    ]
+)
+def test_fourier_filter_identity(funcname, s):
+    da_func = getattr(da_ndf, funcname)
+    sp_func = getattr(sp_ndf, funcname)
+
+    a = np.arange(140.0).reshape(10, 14).astype(complex)
+    d = da.from_array(a, chunks=(5, 7))
+
+    dau.assert_eq(d, da_func(d, s))
+    dau.assert_eq(sp_func(a, s), da_func(d, s))
+
+
+@pytest.mark.parametrize(
     "dtype",
     [
         int,
@@ -70,17 +88,16 @@ def test_fourier_filter_err(funcname, err_type, s, n):
         "fourier_gaussian",
     ]
 )
-def test_fourier_filter_identity(funcname, s, dtype):
+def test_fourier_filter_identity(funcname, dtype):
+    s = 1
+
     da_func = getattr(da_ndf, funcname)
     sp_func = getattr(sp_ndf, funcname)
 
     a = np.arange(140.0).reshape(10, 14).astype(dtype)
     d = da.from_array(a, chunks=(5, 7))
 
-    x = sp_func(a, s)
-
-    dau.assert_eq(d.astype(x.dtype), da_func(d, s))
-    dau.assert_eq(x, da_func(d, s))
+    dau.assert_eq(sp_func(a, s), da_func(d, s))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
For the identity test we don't really need to concern ourselves with types if we always use complex as the result will always be complex. So just do that.

As for the type test, we want to be able to test things that don't have an identity operation. So simply pick some reasonable shift, size, or similar that will work for this sort of test and merely permute types to make sure our implementations behave like SciPy's.