### PR TITLE
Consolidate input array normalization

### DIFF
--- a/dask_ndfourier/__init__.py
+++ b/dask_ndfourier/__init__.py
@@ -58,11 +58,8 @@ def fourier_gaussian(input, sigma, n=-1, axis=-1):
     >>> ax1.imshow(ascent)
     """
 
-    if issubclass(input.dtype.type, numbers.Integral):
-        input = input.astype(float)
-
     # Validate and normalize arguments
-    sigma, n, axis = _utils._norm_args(input, sigma, n=n, axis=axis)
+    input, sigma, n, axis = _utils._norm_args(input, sigma, n=n, axis=axis)
 
     # Compute frequencies
     ang_freq_grid = _utils._get_ang_freq_grid(
@@ -126,7 +123,7 @@ def fourier_shift(input, shift, n=-1, axis=-1):
         input = input.astype(complex)
 
     # Validate and normalize arguments
-    shift, n, axis = _utils._norm_args(input, shift, n=n, axis=axis)
+    input, shift, n, axis = _utils._norm_args(input, shift, n=n, axis=axis)
 
     # Constants with type converted
     J = input.dtype.type(1j)
@@ -191,11 +188,8 @@ def fourier_uniform(input, size, n=-1, axis=-1):
     >>> plt.show()
     """
 
-    if issubclass(input.dtype.type, numbers.Integral):
-        input = input.astype(float)
-
     # Validate and normalize arguments
-    size, n, axis = _utils._norm_args(input, size, n=n, axis=axis)
+    input, size, n, axis = _utils._norm_args(input, size, n=n, axis=axis)
 
     # Get the grid of frequencies
     freq_grid = _utils._get_freq_grid(

--- a/dask_ndfourier/_utils.py
+++ b/dask_ndfourier/_utils.py
@@ -53,6 +53,9 @@ def _get_ang_freq_grid(shape, chunks):
 
 
 def _norm_args(a, s, n=-1, axis=-1):
+    if issubclass(a.dtype.type, numbers.Integral):
+        a = a.astype(float)
+
     if isinstance(s, numbers.Number):
         s = numpy.array(a.ndim * [s])
     elif not isinstance(s, dask.array.Array):
@@ -70,4 +73,4 @@ def _norm_args(a, s, n=-1, axis=-1):
             "Currently `n` other than -1 is unsupported."
         )
 
-    return (s, n, axis)
+    return (a, s, n, axis)

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -17,6 +17,7 @@ import dask_ndfourier._utils
     ]
 )
 def test_norm_args(a, s, n, axis):
-    s2, n2, axis2 = dask_ndfourier._utils._norm_args(a, s, n=n, axis=axis)
+    a2, s2, n2, axis2 = dask_ndfourier._utils._norm_args(a, s, n=n, axis=axis)
 
+    assert isinstance(a2, da.Array)
     assert isinstance(s2, da.Array)


### PR DESCRIPTION
Move input array normalization into `_norm_args` and cut repeated code from the filters. Makes sure the input array is at least real as that is a common expectation. In the case of `fourier_shift` this requirement is not strong enough, so continue handling conversion to complex there first. Given the way normalization of the input array is handled, `fourier_shift` is able to avoid having the input array converted twice since it does this itself. Update the test of `_norm_args` in light of this change.