### PR TITLE
Support 32-bit precision

### DIFF
--- a/dask_ndfourier/__init__.py
+++ b/dask_ndfourier/__init__.py
@@ -64,7 +64,8 @@ def fourier_gaussian(input, sigma, n=-1, axis=-1):
     # Compute frequencies
     ang_freq_grid = _utils._get_ang_freq_grid(
         input.shape,
-        chunks=input.chunks
+        chunks=input.chunks,
+        dtype=sigma.dtype
     )
 
     # Compute Fourier transformed Gaussian
@@ -132,7 +133,8 @@ def fourier_shift(input, shift, n=-1, axis=-1):
     # Get the grid of frequencies
     ang_freq_grid = _utils._get_ang_freq_grid(
         input.shape,
-        chunks=input.chunks
+        chunks=input.chunks,
+        dtype=shift.dtype
     )
 
     # Apply shift
@@ -196,7 +198,8 @@ def fourier_uniform(input, size, n=-1, axis=-1):
     # Get the grid of frequencies
     freq_grid = _utils._get_freq_grid(
         input.shape,
-        chunks=input.chunks
+        chunks=input.chunks,
+        dtype=size.dtype
     )
 
     # Compute uniform filter

--- a/dask_ndfourier/_utils.py
+++ b/dask_ndfourier/_utils.py
@@ -22,10 +22,15 @@ except NameError:
     irange = range
 
 
-def _get_freq_grid(shape, chunks):
+def _get_freq_grid(shape, chunks, dtype=float):
     assert len(shape) == len(chunks)
 
     shape = tuple(shape)
+    dtype = numpy.dtype(dtype).type
+
+    assert (issubclass(dtype, numbers.Real) and
+            not issubclass(dtype, numbers.Integral))
+
     ndim = len(shape)
 
     freq_grid = []
@@ -34,7 +39,8 @@ def _get_freq_grid(shape, chunks):
         sl[i] = slice(None)
         sl = tuple(sl)
 
-        freq_grid_i = _compat._fftfreq(shape[i], chunks=chunks[i])[sl]
+        freq_grid_i = _compat._fftfreq(shape[i],
+                                       chunks=chunks[i]).astype(dtype)[sl]
         for j in itertools.chain(range(i), range(i + 1, ndim)):
             freq_grid_i = freq_grid_i.repeat(shape[j], axis=j)
 

--- a/dask_ndfourier/_utils.py
+++ b/dask_ndfourier/_utils.py
@@ -74,7 +74,9 @@ def _norm_args(a, s, n=-1, axis=-1):
     elif not isinstance(s, dask.array.Array):
         s = numpy.array(s)
 
-    if not issubclass(s.dtype.type, numbers.Real):
+    if issubclass(s.dtype.type, numbers.Integral):
+        s = s.astype(a.real.dtype)
+    elif not issubclass(s.dtype.type, numbers.Real):
         raise TypeError("The `s` must contain real value(s).")
     if s.shape != (a.ndim,):
         raise RuntimeError(

--- a/dask_ndfourier/_utils.py
+++ b/dask_ndfourier/_utils.py
@@ -51,9 +51,16 @@ def _get_freq_grid(shape, chunks, dtype=float):
     return freq_grid
 
 
-def _get_ang_freq_grid(shape, chunks):
-    freq_grid = _get_freq_grid(shape, chunks)
-    ang_freq_grid = 2 * numpy.pi * freq_grid
+def _get_ang_freq_grid(shape, chunks, dtype=float):
+    dtype = numpy.dtype(dtype).type
+
+    assert (issubclass(dtype, numbers.Real) and
+            not issubclass(dtype, numbers.Integral))
+
+    pi = dtype(numpy.pi)
+
+    freq_grid = _get_freq_grid(shape, chunks, dtype=dtype)
+    ang_freq_grid = 2 * pi * freq_grid
 
     return ang_freq_grid
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,6 +3,8 @@
 
 from __future__ import absolute_import
 
+import numbers
+
 import pytest
 
 import numpy as np
@@ -79,14 +81,14 @@ def test_fourier_filter_identity(funcname, s):
     ]
 )
 @pytest.mark.parametrize(
-    "funcname",
+    "funcname, upcast_type",
     [
-        "fourier_shift",
-        "fourier_gaussian",
-        "fourier_uniform",
+        ("fourier_shift", numbers.Real),
+        ("fourier_gaussian", numbers.Integral),
+        ("fourier_uniform", numbers.Integral),
     ]
 )
-def test_fourier_filter_type(funcname, dtype):
+def test_fourier_filter_type(funcname, upcast_type, dtype):
     dtype = np.dtype(dtype).type
 
     s = 1
@@ -98,6 +100,11 @@ def test_fourier_filter_type(funcname, dtype):
     d = da.from_array(a, chunks=(5, 7))
 
     dau.assert_eq(sp_func(a, s), da_func(d, s))
+
+    if issubclass(dtype, upcast_type):
+        assert da_func(d, s).real.dtype.type is np.float64
+    else:
+        assert da_func(d, s).dtype.type is dtype
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -72,7 +72,9 @@ def test_fourier_filter_identity(funcname, s):
     "dtype",
     [
         np.int64,
+        np.float32,
         np.float64,
+        np.complex64,
         np.complex128,
     ]
 )


### PR DESCRIPTION
Fixes https://github.com/dask-image/dask-ndfourier/issues/25

Respects 32-bit precision if the input is of an acceptable type. If not, upcasts to 64-bit precision of an acceptable type anyways.