### PR TITLE
In _get_freq_grid force repeats to an `int`

### DIFF
--- a/dask_ndfourier/_utils.py
+++ b/dask_ndfourier/_utils.py
@@ -42,7 +42,7 @@ def _get_freq_grid(shape, chunks, dtype=float):
         freq_grid_i = _compat._fftfreq(shape[i],
                                        chunks=chunks[i]).astype(dtype)[sl]
         for j in itertools.chain(range(i), range(i + 1, ndim)):
-            freq_grid_i = freq_grid_i.repeat(shape[j], axis=j)
+            freq_grid_i = freq_grid_i.repeat(int(shape[j]), axis=j)
 
         freq_grid.append(freq_grid_i)
 


### PR DESCRIPTION
Appears that the number of repeats provided to Dask Array's `repeat` must be of `int` exactly and not just some general integral type. We have proposed a fix to Dask to relax this constraint in `repeat` to accept all integral values, which has recently been accepted. ( https://github.com/dask/dask/pull/2371 )

However it is quite peculiar that a Dask Array would have a shape that is not just a `tuple` of `int`s. It appears there are some operations with Dask Arrays that cause the shape to be a `tuple` of `numpy.int64`s instead. This appears to be happening with filters from `dask-ndfilters`. ( https://github.com/dask-image/dask-ndfilters/issues/26 ) Though it is unclear whether the origin is there or in Dask Array as well. In the interim, this should workaround the issue until we better understand what is happening and resolve the underlying cause.