### PR TITLE
Preserve chunking in Fourier filters

### DIFF
--- a/dask_ndfourier/_compat.py
+++ b/dask_ndfourier/_compat.py
@@ -51,18 +51,21 @@ def _fftfreq(n, d=1.0, chunks=None):
     Borrowed from my Dask Array contribution.
     """
     n = int(n)
-    chunks = dask.array.core.normalize_chunks(chunks, (n,))[0] + (1,)
+    chunks = dask.array.core.normalize_chunks(chunks, (n,))
 
     n_1 = n + 1
     n_2 = n_1 // 2
 
-    s = dask.array.linspace(0, 1, n_1, chunks=chunks)
+    s = dask.array.linspace(0, 1, n_1, chunks=(chunks[0] + (1,),))
 
     l, r = s[:n_2], s[n_2:-1]
 
     a = l
     if len(r):
         a = dask.array.concatenate([l, r - 1])
+
+    if a.chunks != chunks:
+        a = a.rechunk(chunks)
 
     a /= d
 

--- a/dask_ndfourier/_compat.py
+++ b/dask_ndfourier/_compat.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+"""
+Content here is borrowed from our contributions to Dask.
+"""
+
 
 import itertools
 

--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+"""
+Content here is borrowed from our contributions to Dask.
+"""
+
 
 import pytest
 

--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -9,6 +9,7 @@ import pytest
 
 import numpy as np
 
+import dask.array.core as dac
 import dask.array.utils as dau
 
 import dask_ndfourier._compat
@@ -19,7 +20,10 @@ import dask_ndfourier._compat
 @pytest.mark.parametrize("c", [lambda m: m, lambda m: (1, m - 1)])
 def test_fftfreq(n, d, c):
     c = c(n)
-    dau.assert_eq(
-        dask_ndfourier._compat._fftfreq(n, d, chunks=c),
-        np.fft.fftfreq(n, d)
-    )
+
+    r1 = np.fft.fftfreq(n, d)
+    r2 = dask_ndfourier._compat._fftfreq(n, d, chunks=c)
+
+    assert dac.normalize_chunks(c, r2.shape) == r2.chunks
+
+    dau.assert_eq(r1, r2)

--- a/tests/test__compat.py
+++ b/tests/test__compat.py
@@ -16,8 +16,10 @@ import dask_ndfourier._compat
 
 @pytest.mark.parametrize("n", [1, 2, 3, 6, 7])
 @pytest.mark.parametrize("d", [1.0, 0.5, 2 * np.pi])
-def test_fftfreq(n, d):
+@pytest.mark.parametrize("c", [lambda m: m, lambda m: (1, m - 1)])
+def test_fftfreq(n, d, c):
+    c = c(n)
     dau.assert_eq(
-        dask_ndfourier._compat._fftfreq(n, d, chunks=((n,),)),
+        dask_ndfourier._compat._fftfreq(n, d, chunks=c),
         np.fft.fftfreq(n, d)
     )

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -66,8 +66,13 @@ def test_fourier_filter_identity(funcname, s):
     a = np.arange(140.0).reshape(10, 14).astype(complex)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(d, da_func(d, s))
-    dau.assert_eq(sp_func(a, s), da_func(d, s))
+    r_a = sp_func(a, s)
+    r_d = da_func(d, s)
+
+    assert d.chunks == r_d.chunks
+
+    dau.assert_eq(d, r_d)
+    dau.assert_eq(r_a, r_d)
 
 
 @pytest.mark.parametrize(
@@ -99,12 +104,17 @@ def test_fourier_filter_type(funcname, upcast_type, dtype):
     a = np.arange(140.0).reshape(10, 14).astype(dtype)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(sp_func(a, s), da_func(d, s))
+    r_a = sp_func(a, s)
+    r_d = da_func(d, s)
+
+    assert d.chunks == r_d.chunks
+
+    dau.assert_eq(r_a, r_d)
 
     if issubclass(dtype, upcast_type):
-        assert da_func(d, s).real.dtype.type is np.float64
+        assert r_d.real.dtype.type is np.float64
     else:
-        assert da_func(d, s).dtype.type is dtype
+        assert r_d.dtype.type is dtype
 
 
 @pytest.mark.parametrize(
@@ -132,9 +142,12 @@ def test_fourier_filter_non_positive(funcname, s):
     a = np.arange(140.0).reshape(10, 14).astype(complex)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(
-        sp_func(a, s), da_func(d, s)
-    )
+    r_a = sp_func(a, s)
+    r_d = da_func(d, s)
+
+    assert d.chunks == r_d.chunks
+
+    dau.assert_eq(r_a, r_d)
 
 
 @pytest.mark.parametrize(
@@ -163,6 +176,9 @@ def test_fourier_filter(funcname, s):
     a = np.arange(140.0).reshape(10, 14).astype(complex)
     d = da.from_array(a, chunks=(5, 7))
 
-    dau.assert_eq(
-        sp_func(a, s), da_func(d, s)
-    )
+    r_a = sp_func(a, s)
+    r_d = da_func(d, s)
+
+    assert d.chunks == r_d.chunks
+
+    dau.assert_eq(r_a, r_d)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -118,6 +118,43 @@ def test_fourier_filter_type(funcname, upcast_type, dtype):
 
 
 @pytest.mark.parametrize(
+    "shape, chunks",
+    [
+        ((10, 14), (10, 14)),
+        ((10, 14), (5, 7)),
+        ((10, 14), (6, 8)),
+        ((10, 14), (4, 6)),
+        ((16,), (3, 6, 2, 5)),
+    ]
+)
+@pytest.mark.parametrize(
+    "funcname",
+    [
+        "fourier_shift",
+        "fourier_gaussian",
+        "fourier_uniform",
+    ]
+)
+def test_fourier_filter_chunks(funcname, shape, chunks):
+    dtype = np.dtype(complex).type
+
+    s = 1
+
+    da_func = getattr(da_ndf, funcname)
+    sp_func = getattr(sp_ndf, funcname)
+
+    a = np.arange(np.prod(shape)).reshape(shape).astype(dtype)
+    d = da.from_array(a, chunks=chunks)
+
+    r_a = sp_func(a, s)
+    r_d = da_func(d, s)
+
+    assert d.chunks == r_d.chunks
+
+    dau.assert_eq(r_a, r_d)
+
+
+@pytest.mark.parametrize(
     "s",
     [
         -1,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -159,6 +159,7 @@ def test_fourier_filter_non_positive(funcname, s):
         (0.8, 1.5),
         np.ones((2,)),
         da.ones((2,), chunks=(2,)),
+        da.ones((2,), chunks=(1,)),
     ]
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes https://github.com/dask-image/dask-ndfourier/issues/32

Backports some changes we made to Dask's `fftfreq` into our `_compat` version of `fftfreq` to ensure that it properly constructs an array with the user requested chunking (rechunking if needed). Also backport our test updates to make sure this function is behaving correctly.

This seems to resolve our need to `rechunk` after using Fourier filters on Dask arrays. To guarantee this going forward, tests our updated to ensure that chunking is preserved after Fourier filters are applied. Also added a new test to make sure various shapes and chunks still gave the same chunking and correct result.